### PR TITLE
A Set of Tests for Checking that the ResponsiveSafeArea is Working as Expected

### DIFF
--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,30 +1,96 @@
-// This is a basic Flutter widget test.
-//
-// To perform an interaction with a widget in your test, use the WidgetTester
-// utility that Flutter provides. For example, you can send tap and scroll
-// gestures. You can also use WidgetTester to find child widgets in the widget
-// tree, read text, and verify that the values of widget properties are correct.
-
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'package:responsive_safe_area_tutorial/main.dart';
+import 'package:test_utils/test_utils.dart';
+
+import 'package:responsive_safe_area/responsive_safe_area.dart';
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
-    await tester.pumpWidget(MyApp());
+  MaterialApp materialAppWrapper(Widget widget) =>
+      MaterialApp(home: Material(child: widget));
+  
+  group('Testing widgets for recognition of the status bar', () {
+    const double screenWidth = 600, screenHeight = 800;
+    const Size screenSize = Size(screenWidth, screenHeight);
 
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
+    final TestWidgetsFlutterBinding binding =
+      TestWidgetsFlutterBinding.ensureInitialized();
 
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
+    void setBinding(){
+      binding.window.devicePixelRatioTestValue = 1;
+      binding.window.physicalSizeTestValue = screenSize;
+    }
 
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+    testWidgets(
+        'Checks that the `LayoutBuilder` does *not* recognize the presence of '
+        'the Status Bar', (WidgetTester tester) async {
+      setBinding();
+
+      double extractedHeight;
+
+      final MaterialApp layoutBuilderApp = materialAppWrapper(
+        SampleScreenWithArtificialStatusBar(
+          widget: LayoutBuilder(
+            builder: (_, BoxConstraints constraints) {
+              extractedHeight = constraints.biggest.height;
+              return Container();
+            },
+          ),
+        ),
+      );
+
+      await tester.pumpWidget(layoutBuilderApp);
+
+      expect(extractedHeight, screenHeight);
+    });
+
+    testWidgets(
+        'Checks that the `ResponsiveSafeArea` *does* recognize the presence of '
+        'the Status Bar', (WidgetTester tester) async {
+      setBinding();
+
+      double extractedHeight;
+
+      final MaterialApp responsiveSafeAreaApp = materialAppWrapper(
+        SampleScreenWithArtificialStatusBar(
+          widget: ResponsiveSafeArea(
+            builder: (_, Size constraints) {
+              extractedHeight = constraints.height;
+              return Container();
+            },
+          ),
+        ),
+      );
+
+      await tester.pumpWidget(responsiveSafeAreaApp);
+
+      const double safeHeight = 
+          screenHeight - SampleScreenWithArtificialStatusBar.statusBarHeight;
+
+      expect(extractedHeight, safeHeight);
+    });
   });
+}
+
+class SampleScreenWithArtificialStatusBar extends StatelessWidget {
+  static const double statusBarHeight = 10;
+
+  final Widget widget;
+
+  const SampleScreenWithArtificialStatusBar({
+    Key key, 
+    @required this.widget,
+  }): super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return MediaQuery(
+      data: MediaQuery.of(context).copyWith(
+        padding: EdgeInsets.only(
+          top: statusBarHeight,
+        ),
+      ),
+      child: widget,
+    );
+  }
 }


### PR DESCRIPTION
Some notes:

- I'm using a `MaterialApp` wrapper because the `WidgetTester` often complains if it isn't testing a `Material` widget, I don't know why.
- The first test tests that the `contraints` inside the `LayoutBuilder` don't take into account the artificial padding on top (artificial Status Bar). The second one shows that the `ResponsiveSafeArea` does recognize that difference.
- I think it would be nicer to have the `ResponsiveSafeArea`'s contraints to be of the same type as the `LayoutBuilder`'s, i.e., `BoxConstraints` instead of `Size`, for standardization.